### PR TITLE
Fixing XSS in SIP plugin

### DIFF
--- a/src/java/org/jivesoftware/openfire/util/StringUtils.java
+++ b/src/java/org/jivesoftware/openfire/util/StringUtils.java
@@ -1,0 +1,81 @@
+package org.jivesoftware.openfire.util;
+
+/**
+ * Utility class to perform common String manipulation algorithms.
+ */
+public class StringUtils {
+    
+    private static final char[] LT_ENCODE = "&lt;".toCharArray();
+    private static final char[] GT_ENCODE = "&gt;".toCharArray();
+
+    
+    /**
+     * This method takes a string which may contain HTML tags (ie, &lt;b&gt;,
+     * &lt;table&gt;, etc) and converts the '&lt;' and '&gt;' characters to
+     * their HTML escape sequences. It will also replace LF  with &lt;br&gt;.
+     *
+     * @param in the text to be converted.
+     * @return the input string with the characters '&lt;' and '&gt;' replaced
+     *         with their HTML escape sequences.
+     */
+    public static String escapeHTMLTags(String in) {
+        return escapeHTMLTags(in, true);
+    }
+    
+        /**
+     * This method takes a string which may contain HTML tags (ie, &lt;b&gt;,
+     * &lt;table&gt;, etc) and converts the '&lt;' and '&gt;' characters to
+     * their HTML escape sequences.
+     *
+     * @param in the text to be converted.
+     * @param includeLF set to true to replace \n with <br>.
+     * @return the input string with the characters '&lt;' and '&gt;' replaced
+     *         with their HTML escape sequences.
+     */
+    public static String escapeHTMLTags(String in, boolean includeLF) {
+        if (in == null) {
+            return null;
+        }
+        char ch;
+        int i = 0;
+        int last = 0;
+        char[] input = in.toCharArray();
+        int len = input.length;
+        StringBuilder out = new StringBuilder((int)(len * 1.3));
+        for (; i < len; i++) {
+            ch = input[i];
+            if (ch > '>') {
+            }
+            else if (ch == '<') {
+                if (i > last) {
+                    out.append(input, last, i - last);
+                }
+                last = i + 1;
+                out.append(LT_ENCODE);
+            }
+            else if (ch == '>') {
+                if (i > last) {
+                    out.append(input, last, i - last);
+                }
+                last = i + 1;
+                out.append(GT_ENCODE);
+            }
+            else if (ch == '\n' && includeLF == true) {
+                if (i > last) {
+                    out.append(input, last, i - last);
+                }
+                last = i + 1;
+                out.append("<br>");
+            }
+        }
+        if (last == 0) {
+            return in;
+        }
+        if (i > last) {
+            out.append(input, last, i - last);
+        }
+        return out.toString();
+    }
+
+    
+}

--- a/src/web/sipark-user-summary.jsp
+++ b/src/web/sipark-user-summary.jsp
@@ -21,6 +21,7 @@
         %>
 <%@ page import="org.jivesoftware.openfire.sip.sipaccount.SipAccountDAO" %>
 <%@ page import="org.jivesoftware.openfire.sip.sipaccount.SipAccount" %>
+<%@ page import="org.jivesoftware.openfire.util.StringUtils" %>
 <%@ page import="java.util.Collection" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
@@ -224,7 +225,7 @@
                     <%=user.getStatus().name()%>
                 </td>
                 <td width="20%">
-                    <a href="./../../user-properties.jsp?username=<%= URLEncoder.encode(user.getUsername(), "UTF-8") %>"><%= user.getUsername() %>
+                    <a href="./../../user-properties.jsp?username=<%= URLEncoder.encode(user.getUsername(), "UTF-8") %>"><%= StringUtils.escapeHTMLTags(user.getUsername()) %>
                     </a>
                 </td>
                 <td width="20%">


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-other-openfire-sip-plugin/

### ⚙️ Description *

In the page showing SIP Phone Mappings, the (dangerous) username characters that can cause an XSS are transformed in a way the are not dangerous any more, preserving the correct name visualization of the username

### 💻 Technical Description *

The XSS payload was inserted in the html template without escaping/encoding the dangerous characters. The fix is the followings: creating a StringUtils class (the same used in the Openfire parent project) with a method that HTML-escapes dangerous characters and  using the method to sanitize the  payload so it doesn't work any more

### 🐛 Proof of Concept (PoC) *

The video shows the triggered xss by the payload reported at the bounty url. The version of SIP plugin in video is 1.2.6 installed from the official marketplace

https://user-images.githubusercontent.com/62958189/105225889-8bc69480-5b5f-11eb-8aad-5b93a1c10a82.mp4




### 🔥 Proof of Fix (PoF) *

The video shows that inserting the xss payload, the xss is not triggered anymore. The SIP plugin is the fixed version (snapshot-1.2.7)

https://user-images.githubusercontent.com/62958189/105226104-d6481100-5b5f-11eb-95f8-ed2560e3bfa5.mp4


 
### 👍 User Acceptance Testing (UAT)

After the fix, the page is still working correctly as before the fix and the XSS is not triggered anymore

